### PR TITLE
Remove parameters for read

### DIFF
--- a/hashbang.sh
+++ b/hashbang.sh
@@ -79,7 +79,7 @@ echo " ";
 echo " Please report any issues here: ";
 echo "   -> https://github.com/lrvick/hashbang.sh/issues/";
 echo " ";
-read -n1 -s -p " If you agree with the above and wish to continue, hit [Enter] ";
+read -p " If you agree with the above and wish to continue, hit [Enter] " _;
 
 echo " ";
 echo " ";


### PR DESCRIPTION
The -n and -s parameters do not exist on BSD. Since they don't make any
difference, they should be removed
