### PR TITLE
Fixed path to private key file in generated ~/.ssh/config

### DIFF
--- a/src/hashbang.sh
+++ b/src/hashbang.sh
@@ -256,9 +256,10 @@ if [ "x$key" != "x" -a "x$username" != "x" ]; then
             echo " "
         fi
 
+        private_keyfile=$(echo "$keyfile" | sed 's/.pub$//')
         if ask " Would you like an alias (shortcut) added to your .ssh/config?" Y ; then
             printf "\nHost hashbang\n  HostName ${host}.hashbang.sh\n  User %s\n  IdentityFile %s\n" \
-							"$username" "$keyfile" \
+							"$username" "$private_keyfile" \
             >> ~/.ssh/config
             echo " You can now connect any time by entering the command:";
             echo " ";


### PR DESCRIPTION
IdentityFile should point to the private key file, not the public one.
This change simply uses sed to remove the ".pub" suffix. Maybe a better fix would change how the keyfile variable is handled throughout the script, so feel free to ignore this pull request and do it your way, I just wanted to point to the (apparent) mistake.
I'm on your irc, will say hi in a minute :)