### PR TITLE
Add more shells if needed.

### DIFF
--- a/src/hashbang.sh
+++ b/src/hashbang.sh
@@ -24,6 +24,16 @@ if [ ! "$shell" ]; then
 	exit 1
 fi
 
+if [ "$shell" = "zsh" ]; then
+	printf=$(whereis printf)
+	printline() {
+		$printf ' ' && $printf -- '-%.0s' {1..72}; $printf '\n'
+	}
+else
+	printline() {
+		printf ' ' && printf -- '-%.0s' {1..72}; printf '\n'
+	}
+fi
 bail() {
 	echo " "
 	echo " If you think this is a bug, please report it to ";
@@ -159,7 +169,7 @@ clear
 
 echo " ";
 echo " ";
-printf ' ' && printf -- '-%.0s' {1..72}; printf '\n'
+printline
 echo " ";
 
 echo " First, your system must be properly configured with the required";
@@ -177,7 +187,7 @@ clear;
 
 echo " ";
 echo " ";
-printf ' ' && printf -- '-%.0s' {1..72}; printf '\n'
+printline
 echo " ";
 
 
@@ -207,7 +217,7 @@ while [ "x$username" = "x" ]; do
 done
 
 echo " ";
-printf ' ' && printf -- '-%.0s' {1..72}; printf '\n'
+printline
 echo " ";
 echo " Now we will need an SSH Public Key."
 echo " ";
@@ -271,14 +281,14 @@ fi
 n=0
 hosts=()
 echo
-printf ' ' && printf -- '-%.0s' {1..72}; printf '\n'
+printline
 echo
 echo " Please choose a server to create your account on."
 echo
-printf ' ' && printf -- '-%.0s' {1..72}; printf '\n'
+printline
 printf "  %-1s | %-4s | %-36s | %-8s | %-8s\n" \
 	"#" "Host" "Location" "Users" "Latency"
-printf ' ' && printf -- '-%.0s' {1..72}; printf '\n'
+printline
 while IFS="|" read host ip location current_users max_users; do
 	host=$(echo $host | sed 's/\([a-z0-9]\+\)\..*/\1/g')
 	latency=$(ping -c1 ${host}.hashbang.sh | head -n2 | tail -n1 | sed 's/.*=//g')
@@ -291,7 +301,7 @@ while IFS="|" read host ip location current_users max_users; do
 		"$latency"
 	hosts[$n]=$host
 done <<< "$host_data"
-printf ' ' && printf -- '-%.0s' {1..72}; printf '\n'
+printline
 
 echo
 while true; do
@@ -307,7 +317,7 @@ host=${hosts[$choice]}
 
 if [ "x$public_key" != "x" -a "x$username" != "x" ]; then
 	echo " ";
-	printf ' ' && printf -- '-%.0s' {1..72}; printf '\n'
+	printline
 	echo " ";
 	echo " We are going to create an account with the following information";
 	echo " ";

--- a/src/hashbang.sh
+++ b/src/hashbang.sh
@@ -14,8 +14,13 @@ if [ "x$BASH" != "x" ]; then
 	shell="bash"
 elif [ "x$ZSH_VERSION" != "x" ]; then
 	shell="zsh"
-elif [ readlink /proc/$$/exe = "$(whereis dash)" ]; then
-	shell="dash"
+elif [ "$(readlink /proc/$$/exe)" = "$(which dash)" ]; then
+	echo " "
+	echo " Please run this with 'zsh' or 'bash' instead of 'sh'"
+	echo " Your system automatically links /bin/sh to a shell"
+	echo " called 'dash', which is unsupported by this script"
+	echo " "
+	exit 1
 elif [ ! "$shell" ]; then
 	echo " "
 	echo " Your shell is incompatible with this script"
@@ -276,64 +281,42 @@ if [ "x$public_key" = "x" ]; then
 	done
 	public_key=$(cat "${private_keyfile}.pub")
 fi
-if [ ! "$shell" = "dash" ]; then
-	n=0
-	hosts=()
-	echo
-	printline
-	echo
-	echo " Please choose a server to create your account on."
-	echo
-	printline
-	printf "  %-1s | %-4s | %-36s | %-8s | %-8s\n" \
-		"#" "Host" "Location" "Users" "Latency"
-	printline
-	while IFS="|" read host ip location current_users max_users; do
-		host=$(echo $host | sed 's/\([a-z0-9]\+\)\..*/\1/g')
-		latency=$(ping -c1 ${host}.hashbang.sh | head -n2 | tail -n1 | sed 's/.*=//g')
-		n=$((n+1))
-		printf "  %-1s | %-4s | %-36s | %8s | %-8s\n" \
-			"$n" \
-			"$host" \
-			"$location" \
-			"$current_users/$max_users" \
-			"$latency"
-		hosts[$n]=$host
-	done <<< "$host_data"
-	printline
-	
-	echo
-	while true; do
-		echo -n " Enter Number 1-$n : "
-		read choice
-		if [[ "$choice" =~ ^[0-9]+$ ]] && \
-		   [[ "$choice" -ge 1 ]] && \
-		   [[ "$choice" -le $n ]]; then
-			break;
-		fi
-	done
-	host=${hosts[$choice]}
-else
-	echo " "
-	printline
-	echo " "
-	echo " Your shell ($(readlink /proc/$$/exe)) is incapable"
-	echo " of supporting the 'array' feature, and therefore"
-	echo " cannot list servers. Automatically setting server to"
-	echo " the first available server. If you wish to change"
-	echo " this option, exit the script now and start with a"
-	echo " supported shell, such as zsh or bash."
-	echo " "
-	printline
-	echo " Press enter to continue, or terminate shell [Ctrl-C] to exit: "
-	read _
-	while IFS="|" read host ip location current_users max_users; do
-		if [ ! current_users -eq max_users ]; then
-			host=$(echo $host | sed 's/\([a-z0-9]\+\)\..*/\1/g')
-			break
-		fi
-	done <<< "$host_data"
-fi
+n=0
+hosts=()
+echo
+printline
+echo
+echo " Please choose a server to create your account on."
+echo
+printline
+printf "  %-1s | %-4s | %-36s | %-8s | %-8s\n" \
+	"#" "Host" "Location" "Users" "Latency"
+printline
+while IFS="|" read host ip location current_users max_users; do
+	host=$(echo $host | sed 's/\([a-z0-9]\+\)\..*/\1/g')
+	latency=$(ping -c1 ${host}.hashbang.sh | head -n2 | tail -n1 | sed 's/.*=//g')
+	n=$((n+1))
+	printf "  %-1s | %-4s | %-36s | %8s | %-8s\n" \
+		"$n" \
+		"$host" \
+		"$location" \
+		"$current_users/$max_users" \
+		"$latency"
+	hosts[$n]=$host
+done <<< "$host_data"
+printline
+
+echo
+while true; do
+	echo -n " Enter Number 1-$n : "
+	read choice
+	if [[ "$choice" =~ ^[0-9]+$ ]] && \
+	   [[ "$choice" -ge 1 ]] && \
+	   [[ "$choice" -le $n ]]; then
+		break;
+	fi
+done
+host=${hosts[$choice]}
 if [ "x$public_key" != "x" -a "x$username" != "x" ]; then
 	echo " ";
 	printline

--- a/src/hashbang.sh
+++ b/src/hashbang.sh
@@ -3,16 +3,29 @@
 # Secondly, it attempts to be compatible with as many shell implementations as
 # possible to provide an easy gateway for new users.
 
-# If we're using bash, we do this
+# Check for shell. Many aren't supported.
+shell=""
 if [ "x$BASH" != "x" ]; then
+	# If we're using bash, we do this
 	shopt -s extglob
 	set -o posix
-    # Bail out if any curl's fail
-    set -o pipefail 
+	# Bail out if any curl's fail
+	set -o pipefail
+	shell="bash"
+fi
+if [ "x$ZSH_VERSION" != "x" ]; then
+	shell="zsh"
+fi
+if [ ! "$shell" ]; then
+	echo " "
+	echo " Your shell is incompatible with this script"
+	echo " Please run one of: zsh, bash" # Find a way to automate this?
+	echo " "
+	exit 1
 fi
 
 bail() {
-    echo " "
+	echo " "
 	echo " If you think this is a bug, please report it to ";
 	echo " -> https://github.com/hashbang/hashbang.sh/issues/";
 	echo " ";
@@ -60,7 +73,7 @@ ask() {
 		fi
 
 		# Ask the question
-        echo " "
+		echo " "
 		printf "%s [%s] " "$1" "$prompt"
 		read REPLY
 
@@ -76,7 +89,7 @@ ask() {
 		esac
 
 	done
-    echo " "
+	echo " "
 }
 
 # generate ssh kypair
@@ -264,18 +277,18 @@ echo " Please choose a server to create your account on."
 echo
 printf ' ' && printf -- '-%.0s' {1..72}; printf '\n'
 printf "  %-1s | %-4s | %-36s | %-8s | %-8s\n" \
-    "#" "Host" "Location" "Users" "Latency"
+	"#" "Host" "Location" "Users" "Latency"
 printf ' ' && printf -- '-%.0s' {1..72}; printf '\n'
 while IFS="|" read host ip location current_users max_users; do
 	host=$(echo $host | sed 's/\([a-z0-9]\+\)\..*/\1/g')
 	latency=$(ping -c1 ${host}.hashbang.sh | head -n2 | tail -n1 | sed 's/.*=//g')
 	n=$((n+1))
 	printf "  %-1s | %-4s | %-36s | %8s | %-8s\n" \
-	    "$n" \
-	    "$host" \
-	    "$location" \
-	    "$current_users/$max_users" \
-	    "$latency"
+		"$n" \
+		"$host" \
+		"$location" \
+		"$current_users/$max_users" \
+		"$latency"
 	hosts[$n]=$host
 done <<< "$host_data"
 printf ' ' && printf -- '-%.0s' {1..72}; printf '\n'
@@ -287,7 +300,7 @@ while true; do
 	if [[ "$choice" =~ ^[0-9]+$ ]] && \
 	   [[ "$choice" -ge 1 ]] && \
 	   [[ "$choice" -le $n ]]; then
-	    break;
+		break;
 	fi
 done
 host=${hosts[$choice]}
@@ -303,61 +316,60 @@ if [ "x$public_key" != "x" -a "x$username" != "x" ]; then
 	echo " Host: $host";
 	echo " ";
 	if ask " Does this look correct?" Y ; then
-	
-	    echo " ";
-	    echo -n " Creating your account... ";
-	    if curl --silent -f -H "Content-Type: application/json" \
-	        -d "{\"user\":\"$username\",\"key\":\"$public_key\",\"host\":\"$host\"}" \
-	        https://hashbang.sh/user/create; then
-	        echo " Account Created!"
-	    else
-	        echo " Account creation failed.";
-	        bail
-	    fi
+		echo " ";
+		echo -n " Creating your account... ";
+		format="{\"user\":\"$username\",\"key\":\"$public_key\",\"host\":\"$host\"}" # helps with embedding below
+		output="$(curl -H 'Content-Type: application/json' -d \"$format\" https://hashbang.sh/user/create)" 2>&- # keep output but close 2nd FD
+		if [ ! $? -eq 0 ]; then
+			echo " Account Created!"
+		else
+			echo " Account creation failed: $(echo $output | sed -e 's/.*\"message\": \?\"\([^"]\+\)\".*/\1/')";
+			bail
+		fi
 
-	    if ask " Would you like to add trusted/signed keys for our servers to your .ssh/known_hosts?" Y ; then
-	        echo " Downloading GPG keys"
-	        echo " "
-	        gpg --recv-keys 0xD2C4C74D8FAA96F5
-	        echo " "
-	        echo " Downloading key list"
-	        echo " "
-	        data="$(curl -s https://hashbang.sh/static/known_hosts.asc)"
-	        printf %s "$data" | gpg --verify
-	        if [ ! $? -eq 0 ]; then
-	            echo " "
-	            echo " Unable to verify keys"
-	            bail
-	        fi
-	        printf %s "$data" | grep "hashbang.sh" >> ~/.ssh/known_hosts
-	        echo " "
-	        echo " Key scanned and saved"
-	    fi
+		if ask " Would you like to add trusted/signed keys for our servers to your .ssh/known_hosts?" Y ; then
+			echo " Downloading GPG keys"
+			echo " "
+			gpg --recv-keys 0xD2C4C74D8FAA96F5
+			echo " "
+			echo " Downloading key list"
+			echo " "
+			data="$(curl -s https://hashbang.sh/static/known_hosts.asc)"
+			printf %s "$data" | gpg --verify
+			if [ ! $? -eq 0 ]; then
+				echo " "
+				echo " Unable to verify keys"
+				bail
+			fi
+			printf %s "$data" | grep "hashbang.sh" >> ~/.ssh/known_hosts
+			echo " "
+			echo " Key scanned and saved"
+		fi
 
-	    if ask " Would you like an alias (shortcut) added to your .ssh/config?" Y ; then
-	        printf "\nHost hashbang\n  HostName ${host}.hashbang.sh\n  User %s\n  IdentityFile %s\n" \
+		if ask " Would you like an alias (shortcut) added to your .ssh/config?" Y ; then
+			printf "\nHost hashbang\n  HostName ${host}.hashbang.sh\n  User %s\n  IdentityFile %s\n" \
 							"$username" "$private_keyfile" \
-	        >> ~/.ssh/config
-	        echo " You can now connect any time by entering the command:";
-	        echo " ";
-	        echo " > ssh hashbang";
-	    else
-	        echo " You can now connect any time by entering the command:";
-	        echo " ";
-	        echo " > ssh ${username}@${host}.hashbang.sh";
-	    fi
+			>> ~/.ssh/config
+			echo " You can now connect any time by entering the command:";
+			echo " ";
+			echo " > ssh hashbang";
+		else
+			echo " You can now connect any time by entering the command:";
+			echo " ";
+			echo " > ssh ${username}@${host}.hashbang.sh";
+		fi
 
 	else
-	    echo " Please re-run script to make corrections.";
+		echo " Please re-run script to make corrections.";
 		bail
 	fi
 
 	if ask " Do you want us to log you in now?" Y; then
-	    if [ -e $private_keyfile ]; then
-	        ssh ${username}@${host}.hashbang.sh -i "$private_keyfile"
-        else
-            ssh ${username}@${host}.hashbang.sh
-        fi
+		if [ -e $private_keyfile ]; then
+			ssh ${username}@${host}.hashbang.sh -i "$private_keyfile"
+		else
+			ssh ${username}@${host}.hashbang.sh
+		fi
 	fi
 fi
 


### PR DESCRIPTION
Check to see if shell is on compatible list.
Shells can be added into the checks up top.
/bin/dash or /bin/ash (which is also /bin/sh in Debian) does not support arrays.
I will clean up code later to check if the shell is dash -somehow- to skip the section of arrays.
Then, a check will be added to the start to set the shell=dash.