### PR TITLE
Use portable mktemp invocation

### DIFF
--- a/src/hashbang.sh
+++ b/src/hashbang.sh
@@ -13,7 +13,7 @@ fi
 
 # Fetch host data for later.
 # If this fails there is no point in proceeding
-host_data=$(mktemp)
+host_data=$(mktemp /tmp/hashbang.XXXXXX)
 curl -sH 'Accept:text/plain' https://hashbang.sh/server/stats > $host_data
 err=$?
 echo >> $host_data


### PR DESCRIPTION
Invoking mktemp without arguments is not portable. On BSD and Mac OS X, mktemp needs an argument with a template ending in six capital letters X.