### PR TITLE
Prevent POODLE attack by not allowing SSLv3

### DIFF
--- a/server.py
+++ b/server.py
@@ -4,6 +4,7 @@ import os
 import sys
 import csv
 import ldap
+import ssl
 from subprocess import check_call, CalledProcessError
 from flask import Flask, send_from_directory, redirect, request, make_response
 from flask.ext.restful import Resource, Api
@@ -122,6 +123,7 @@ if __name__ == '__main__':
           ssl_options={
               "certfile": certfile,
               "keyfile": keyfile,
+              "ssl_version": ssl.PROTOCOL_TLSv1
           }
         )
         https_server.listen(https_port)


### PR DESCRIPTION
The POODLE attack is a man-in-the-middle exploit which takes advantage of fallbacks to SSLv3.

This pull request makes it so that only TLSv1 or higher can be used for https.

Thanks to [/u/AyrA_ch on reddit](https://www.reddit.com/r/commandline/comments/3dtpjj/_/ct91rp9), for reporting this issue. This can be tested via https://www.ssllabs.com/ssltest/analyze.html?d=hashbang.sh.