### PR TITLE
src/hashbang.sh: Saner priority for SSH keys

### DIFF
--- a/src/hashbang.sh
+++ b/src/hashbang.sh
@@ -207,7 +207,7 @@ echo " SSH Keys are a type of public/private key system that let you identify";
 echo " yourself to systems like this one without ever sending your password ";
 echo " over the internet, and thus by nature we won't even know what it is";
 
-for keytype in id_rsa id_dsa id_ecdsa id_ed25519; do
+for keytype in id_ed25519 id_ecdsa id_rsa id_dsa; do
 	if [ -e ~/.ssh/${keytype}.pub ] && [ -e ~/.ssh/${keytype} ]; then
 		if ask " We found a public key in [ ~/.ssh/${keytype}.pub ]. Use this key?" Y; then
 			private_keyfile="~/.ssh/${keytype}"


### PR DESCRIPTION
Since only one SSH key is selected, we should probe for safer authentication methods first.

I considered putting ECDSA after RSA, due to the nonce issues in *DSA, but it is hard to make a choice without more user-specific information (esp. the keysize).