### PR TITLE
Fail on non-200 HTTP codes.

### DIFF
--- a/src/hashbang.sh
+++ b/src/hashbang.sh
@@ -14,7 +14,7 @@ fi
 # Fetch host data for later.
 # If this fails there is no point in proceeding
 host_data=$(mktemp /tmp/hashbang.XXXXXX)
-curl -sH 'Accept:text/plain' https://hashbang.sh/server/stats > $host_data
+curl -sfH 'Accept:text/plain' https://hashbang.sh/server/stats > $host_data
 err=$?
 echo >> $host_data
 


### PR DESCRIPTION
Right now the script silently continues if curl receives a non-200 status code, which is currently happening with the endpoint ```https://hashbang.sh/server/stats```:

This change enforces the ```-f/--force``` flag on the initial curl call, which will cause the script to error and exit gracefully.

```
# Without flag
[smw ~]$ curl --head "https://hashbang.sh/server/stats"; echo $?
HTTP/1.1 500 INTERNAL SERVER ERROR
Content-Type: application/json
Content-Length: 51
Server: TornadoServer/4.1

0

# With flag
[smw ~]$ curl --head -f "https://hashbang.sh/server/stats"; echo $?
curl: (22) The requested URL returned error: 500 INTERNAL SERVER ERROR
22
```