### PR TITLE
Compatibility with Darwin's `ping'

### DIFF
--- a/src/hashbang.sh
+++ b/src/hashbang.sh
@@ -275,7 +275,7 @@ printf "  %-1s | %-4s | %-36s | %-8s | %-8s\n" \
 printf -- ' %72s\n' | tr ' ' -;
 while IFS="|" read host ip location current_users max_users; do
 	host=$(echo $host | sed 's/\([a-z0-9]\+\)\..*/\1/g')
-	latency=$(ping -c1 ${host}.hashbang.sh | head -n2 | tail -n1 | sed 's/.*=//g')
+	latency=$(ping -c 1 ${host}.hashbang.sh | head -n2 | tail -n1 | sed 's/.*=//g')
 	n=$((n+1))
 	printf "  %-1s | %-4s | %-36s | %8s | %-8s\n" \
 		"$n" \


### PR DESCRIPTION
OS X's `ping` (expanded from Darwin's version of `ping`) was shown to be incompatible with the `-c1` flag. I added in a space.