### PR TITLE
server.py: Fixup the (not-so-strict) CSP

### DIFF
--- a/server.py
+++ b/server.py
@@ -125,9 +125,9 @@ api.add_resource(ServerStats, '/server/stats')
 
 
 def security_headers(response, secure=False):
-    csp = "default-src 'none'; "                     \
-          "style-src https://fonts.googleapis.com; " \
-          "fonts-src https://fonts.gstatic.com; "    \
+    csp = "default-src 'none'; "                                     \
+          "style-src https://fonts.googleapis.com 'unsafe-inline'; " \
+          "font-src https://fonts.gstatic.com; "                     \
           "img-src data:; script-src 'unsafe-inline'"
     response.headers['Content-Security-Policy-Report-Only'] = csp
 


### PR DESCRIPTION
This makes the CSP work with the current content, with no attempt (yet) to remove the two `unsafe-inline`s.