### PR TITLE
Better TLS configuration

### DIFF
--- a/server.py
+++ b/server.py
@@ -171,14 +171,25 @@ def assets(filename):
 if __name__ == '__main__':
 
     if os.path.isfile(certfile) and os.path.isfile(keyfile):
+        ssl_ctx = ssl.create_default_context()
+        ssl_ctx.load_cert_chain(certfile, keyfile)
+
+        # Protocol options: allow TLSv1.1 and later
+        ssl_ctx.options |= ssl.OP_NO_SSLv2
+        ssl_ctx.options |= ssl.OP_NO_SSLv3
+        ssl_ctx.options |= ssl.OP_NO_TLSv1
+
+        # Cipher options: strong ciphers, follow server preferences
+        ssl_ctx.set_ciphers("ECDH+AESGCM128:ECDH+AESGCM256:ECDH+AES128:ECDH+AES256:!aNULL:!MD5:!RC4:!DSS:!EXPORT")
+        ssl_ctx.options |= ssl.OP_CIPHER_SERVER_PREFERENCE
+
+        # Key exchange: strong prime curve, no point reuse
+        ssl_ctx.set_ecdh_curve('secp521r1')
+        ssl_ctx.options |= ssl.OP_SINGLE_ECDH_USE
+
         https_server = HTTPServer(
             WSGIContainer(app),
-            ssl_options={
-                "certfile": certfile,
-                "keyfile": keyfile,
-                "ssl_version": ssl.PROTOCOL_TLSv1_2,
-                "ciphers": "ECDH+AESGCM128:ECDH+AESGCM256:ECDH+AES128:ECDH+AES256:!aNULL:!MD5:!RC4:!DSS:!EXPORT"
-            }
+            ssl_options=ssl_ctx
         )
         https_server.listen(https_port)
 

--- a/server.py
+++ b/server.py
@@ -180,7 +180,7 @@ if __name__ == '__main__':
         ssl_ctx.options |= ssl.OP_NO_TLSv1
 
         # Cipher options: strong ciphers, follow server preferences
-        ssl_ctx.set_ciphers("ECDH+AESGCM128:ECDH+AESGCM256:ECDH+AES128:ECDH+AES256:!aNULL:!MD5:!RC4:!DSS:!EXPORT")
+        ssl_ctx.set_ciphers("ECDH+AESGCM128:ECDH+AESGCM256:ECDH+AES128+SHA256:ECDH+AES256+SHA256:!aNULL:!MD5:!RC4:!DSS:!EXPORT")
         ssl_ctx.options |= ssl.OP_CIPHER_SERVER_PREFERENCE
 
         # Key exchange: strong prime curve, no point reuse


### PR DESCRIPTION
- Allow TLSv1.1 and later
- Honor the server's cipher preferences
- Provide strong forward-secrecy with a widely-supported 521b curve and don't reuse ECDH parameters.