### PR TITLE
Enforce the Content-Security-Policy

### DIFF
--- a/server.py
+++ b/server.py
@@ -131,11 +131,11 @@ def security_headers(response, secure=False):
           "img-src data:; script-src 'self'; "              \
           "sandbox allow-same-origin allow-scripts; "       \
           "frame-ancestors 'none'"
-    response.headers['Content-Security-Policy-Report-Only'] = csp
 
-    response.headers['X-Content-Type-Options'] = 'nosniff'
-    response.headers['X-Frame-Options']        = 'DENY'
-    response.headers['X-XSS-Protection']       = '1; mode=block'
+    response.headers['Content-Security-Policy'] = csp
+    response.headers['X-Content-Type-Options']  = 'nosniff'
+    response.headers['X-Frame-Options']         = 'DENY'
+    response.headers['X-XSS-Protection']        = '1; mode=block'
 
     if secure:
         response.headers['Strict-Transport-Security'] = 'max-age=31536000'


### PR DESCRIPTION
No change compared to the working CSP-Report-Only that is currently deployed in production.

Somebody confirming that there is no violation reported in the browser console in Chrome/Chromium would be nice; I already tested with the Tor Browser (Firefox ESR).