### PR TITLE
Travis: Cache ~/.gnupg

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 sudo: required
 dist: trusty
 
+cache:
+  directories:
+    - $HOME/.gnupg
+
 before_install:
   - echo 'deb http://archive.ubuntu.com/ubuntu trusty-backports main restricted universe multiverse' | sudo tee -a /etc/apt/sources.list
   - sudo apt-get -qq update

--- a/test.sh
+++ b/test.sh
@@ -3,11 +3,13 @@
 # Actually rebuild the static pages
 make default
 
+# Fetch the signing key if needed or if in the CI environment
+if [ -n "$CI" ] || !gpg --quiet -k 0xD2C4C74D8FAA96F5; then
+    gpg --recv-keys --keyserver keys.gnupg.net 0xD2C4C74D8FAA96F5
+fi
 
 # Check the OpenPGP signatures
 rm -f -- index.html.data known_hosts warn.sh
-gpg --quiet -k 0xD2C4C74D8FAA96F5 ||
-    gpg --recv-keys --keyserver keys.gnupg.net 0xD2C4C74D8FAA96F5
 
 gpg -d -o index.html.data static/index.html
 diff -q index.html.data static/index.html.plain


### PR DESCRIPTION
This should make the CI slightly more reliable (a build can fail if it fails to reach a keyserver, otherwise)