### PR TITLE
Change ssh config file permissions if it was just created

### DIFF
--- a/src/hashbang.sh
+++ b/src/hashbang.sh
@@ -358,6 +358,7 @@ if [ -n "$public_key" ] && [ -n "$username" ]; then
 			printf '\nHost hashbang\n  HostName %s\n  IdentitiesOnly yes\n  User %s\n  IdentityFile %s\n' \
 			       "${host}" "$username" "$private_keyfile" \
 			>> ~/.ssh/config
+			chmod 600 ~/.ssh/config
 			echo " You can now connect any time by entering the command:";
 			echo " ";
 			echo " > ssh hashbang";


### PR DESCRIPTION
If `~/.ssh/config` does not exist before `printf`, it will be created with the permissions defined by `umask` which may be not compatible with ssh permission requirements, which will render user's SSH client unusable with the following error:
`Bad owner or permissions on /home/username/.ssh/config`