### PR TITLE
Fix typo and link to regexp

### DIFF
--- a/src/hashbang.sh
+++ b/src/hashbang.sh
@@ -200,7 +200,7 @@ while [ "x$username" = "x" ]; do
 	read -r input;
 
 	# Keep in sync with the description and
-	#  https://github.com/hashbang/provisor/blob/master/provisor/utils.py#L77
+	#  https://github.com/hashbang/provisor/blob/master/provisor/utils.py#L56
 	if echo "$input" | grep -E "^[a-z][a-z0-9]{0,30}$" >/dev/null; then
 		username="$input"
 	else

--- a/src/hashbang.sh
+++ b/src/hashbang.sh
@@ -101,7 +101,7 @@ ask() {
 	echo " "
 }
 
-# generate ssh kypair
+# generate ssh keypair
 makekey() {
 	( checkutil ssh-keygen && checkutil ssh ) || bail
 	if [ ! -e "$1" ]; then


### PR DESCRIPTION
These changes are rather trivial. One commit fixes typo, another commit fixes link (in comment) to regexp in provisor/utils.py.